### PR TITLE
Update required Node version to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "engines": {
-    "node": ">=12.x.x <=16.x.x",
+    "node": ">=12.x.x <=18.x.x",
     "npm": ">=6.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This package still works on Node 18. I just bumped the version number so it will install properly.